### PR TITLE
Add tests for Talk class

### DIFF
--- a/meetup_facebook_bot/server.py
+++ b/meetup_facebook_bot/server.py
@@ -51,10 +51,10 @@ def webhook():
             message_handlers.handle_message_with_sender_id
         )
     ]
+    access_token = app.config['ACCESS_TOKEN']
     for messaging_event in messaging_events:
         for message_validator, message_handler in message_processors:
             if message_validator(messaging_event):
-                access_token = app.config['ACCESS_TOKEN']
                 message_handler(messaging_event, access_token, db_session)
     return 'Success.', 200
 

--- a/tests/models/talk_test.py
+++ b/tests/models/talk_test.py
@@ -1,0 +1,17 @@
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+from meetup_facebook_bot.models import talk
+
+class TalkTestCase(TestCase):
+
+    def test_is_liked_by(self):
+        pass
+
+    def test_set_like(self):
+        pass
+
+    def test_unset_like(self):
+        pass
+
+    def test_revert_like(self):
+        pass

--- a/tests/models/talk_test.py
+++ b/tests/models/talk_test.py
@@ -1,32 +1,28 @@
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
+
 from meetup_facebook_bot.models.talk import Talk
 
-class TalkTestCase(TestCase):
 
+class TalkTestCase(TestCase):
     def setUp(self):
         self.db_session = MagicMock()
+        self.like_mock = MagicMock()
         self.user_id = 1
         self.talk_id = 1
+        self.talk = Talk(id=self.talk_id)
 
     @patch('meetup_facebook_bot.models.talk.Like')
     def test_set_like(self, like_class_mock):
-        talk = Talk(id=self.talk_id)
-        mock_like = MagicMock()
-        like_class_mock.return_value = mock_like
-        talk.is_liked_by = MagicMock(return_value=False)
-        talk.set_like(self.user_id, self.db_session)
+        like_class_mock.return_value = self.like_mock
+        self.talk.is_liked_by = MagicMock(return_value=False)
+        self.talk.set_like(self.user_id, self.db_session)
         like_class_mock.assert_called_once_with(user_facebook_id=self.user_id, talk_id=self.talk_id)
-        self.db_session.add.assert_called_once_with(mock_like)
+        self.db_session.add.assert_called_once_with(self.like_mock)
 
     def test_unset_like(self):
-        talk = Talk(id=self.talk_id)
-        talk.is_liked_by = MagicMock(return_value=True)
-        like_mock = MagicMock()
-        scalar_mock = MagicMock(return_value=like_mock)
+        self.talk.is_liked_by = MagicMock(return_value=True)
+        scalar_mock = MagicMock(return_value=self.like_mock)
         self.db_session.query().filter_by().scalar = scalar_mock
-        talk.unset_like(self.user_id, self.db_session)
-        self.db_session.delete.assert_called_once_with(like_mock)
-
-    def test_revert_like(self):
-        pass
+        self.talk.unset_like(self.user_id, self.db_session)
+        self.db_session.delete.assert_called_once_with(self.like_mock)

--- a/tests/models/talk_test.py
+++ b/tests/models/talk_test.py
@@ -1,17 +1,34 @@
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
-from meetup_facebook_bot.models import talk
+from meetup_facebook_bot.models.talk import Talk
 
 class TalkTestCase(TestCase):
+
+    def setUp(self):
+        self.db_session = MagicMock()
+        self.user_id = 1
+        self.talk_id = 1
+
 
     def test_is_liked_by(self):
         pass
 
-    def test_set_like(self):
-        pass
+
+    @patch('meetup_facebook_bot.models.talk.Like')
+    def test_set_like(self, like_class_mock):
+        talk = Talk(id=self.talk_id)
+        mock_like = MagicMock()
+        like_class_mock.return_value = mock_like
+        talk.is_liked_by = MagicMock(return_value=False)
+        talk.set_like(self.user_id, self.db_session)
+        like_class_mock.assert_called_once_with(user_facebook_id=self.user_id, talk_id=self.talk_id)
+        self.db_session.add.assert_called_once_with(mock_like)
 
     def test_unset_like(self):
-        pass
-
-    def test_revert_like(self):
-        pass
+        talk = Talk(id=self.talk_id)
+        talk.is_liked_by = MagicMock(return_value=True)
+        like_mock = MagicMock()
+        scalar_mock = MagicMock(return_value=like_mock)
+        self.db_session.query().filter_by().scalar = scalar_mock
+        talk.unset_like(self.user_id, self.db_session)
+        self.db_session.delete.assert_called_once_with(like_mock)


### PR DESCRIPTION
I wrote tests only for set_like() and unset_like() methods because:
  - revert_like() use only tested functions
  - is_liked_by() and count_likes() use only DB functions and it is strange to mock them and test only mocked objects.