### PR TITLE
Add caching into Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ notifications:
 install: 
   - pip3 install -r requirements.txt
   - pip3 install coveralls
+cache:
+  directories:
+    - $HOME/.cache/pip
+before_cache:
+  - rm -f $HOME/.cache/pip/log/debug.log
 script: 
   - python3 -m pytest tests --cov meetup_facebook_bot
 after_success:


### PR DESCRIPTION
-15 seconds for build because now Travis does not pip all requirements, but use cached.
also it is important that before caching Travis delete our logs, so we would use Travis memory economically
And it is important to say that failure in this phase does not mark the job as failed.